### PR TITLE
runCLI: take ToolIdentity instead of version string (#137)

### DIFF
--- a/Sources/GetClearKit/Commands.swift
+++ b/Sources/GetClearKit/Commands.swift
@@ -32,7 +32,7 @@ public enum Command: String {
 
 /// Parse args, handle version/help/empty, and dispatch to `handler` with a typed `Command`.
 ///
-/// - `.version` → prints version string and exits
+/// - `.version` → prints identity and exits
 /// - `.help` / `.empty` → calls `usage()`
 /// - Unrecognised command string → calls `usage()`
 /// - Known command → calls `handler` with the typed `Command` and filtered arg list
@@ -41,13 +41,13 @@ public enum Command: String {
 /// the command name remains at index 0 so handler code uses `args[1]`, `args[2]`, etc.
 public func runCLI(
     args: [String],
-    version: String,
+    identity: ToolIdentity,
     usage: () -> Never,
     handler: (Command, [String]) -> Void
 ) {
     switch parseArgs(args) {
     case .version:
-        print(version)
+        print(identity)
         exit(0)
     case .help, .empty:
         usage()

--- a/contacts-cli/Sources/ContactsCLI/main.swift
+++ b/contacts-cli/Sources/ContactsCLI/main.swift
@@ -11,7 +11,7 @@ let store     = CNContactStore()
 let semaphore = DispatchSemaphore(value: 0)
 let args      = Array(CommandLine.arguments.dropFirst())
 
-runCLI(args: args, version: "\(identity)", usage: usage) { command, args in
+runCLI(args: args, identity: identity, usage: usage) { command, args in
     store.requestAccess(for: .contacts) { granted, _ in
         guard granted else { fail("Contacts access denied") }
 


### PR DESCRIPTION
## Summary

- Changes `runCLI` parameter from `version: String` to `identity: ToolIdentity`
- `runCLI` now calls `print(identity)` directly for the `.version` case — no string construction at the call site
- Updates contacts (the one tool already using `runCLI`) to pass `identity: identity`
- The four remaining tools still use manual dispatch; they'll adopt `runCLI` in #33

## Test plan

- [ ] 719 tests pass
- [ ] `contacts --version` outputs correct identity line

🤖 Generated with [Claude Code](https://claude.com/claude-code)